### PR TITLE
Close mobile menu on interaction

### DIFF
--- a/src/ui/controllers.js
+++ b/src/ui/controllers.js
@@ -9,6 +9,37 @@
   function bindGlobalControls(doc, state, actions) {
     var addBtn = doc.getElementById('btn-add-player');
     if (!addBtn) return;
+    
+    // Mobile menu handling
+    var navToggle = doc.getElementById('nav-toggle');
+    var globalActions = doc.querySelector('.global-actions');
+    
+    // Close menu when any menu item is clicked
+    if (navToggle && globalActions) {
+      var menuButtons = globalActions.querySelectorAll('.btn, .file-btn');
+      menuButtons.forEach(function(button) {
+        button.addEventListener('click', function() {
+          navToggle.checked = false;
+        });
+      });
+      
+      // Close menu when clicking outside
+      doc.addEventListener('click', function(e) {
+        if (!navToggle.checked) return;
+        
+        var hamburger = doc.querySelector('.hamburger');
+        var clickedInsideMenu = globalActions.contains(e.target);
+        var clickedHamburger = hamburger && hamburger.contains(e.target);
+        
+        // Also check if clicked on the nav-toggle input itself
+        var clickedToggle = e.target === navToggle;
+        
+        if (!clickedInsideMenu && !clickedHamburger && !clickedToggle) {
+          navToggle.checked = false;
+        }
+      });
+    }
+    
     addBtn.addEventListener('click', function () {
       state.players.push(RB.models.defaultPlayer());
       actions.saveState();


### PR DESCRIPTION
Add JavaScript to close the mobile hamburger menu when a menu item is selected or clicking outside, improving mobile user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-fef5c2ad-a1e2-4f16-9fa9-23dc63096456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fef5c2ad-a1e2-4f16-9fa9-23dc63096456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

